### PR TITLE
add test_chgt_nbr_joueurs

### DIFF
--- a/TD4/hanabi_unittest.py
+++ b/TD4/hanabi_unittest.py
@@ -122,6 +122,14 @@ class GameTest(unittest.TestCase):
         game.quiet = True
         game.turn('p3')  # check that we can play blindly
 
+
+    def test_chgt_nbr_joueurs(self):
+        for i in range (2,6):
+            game = hanabi.Game(i)
+            ai = hanabi.ai.Cheater(game)
+            game.ai = ai
+            game.run()
+
     # lines 227, 261
     def test_B1(self):
         pass


### PR DESCRIPTION
Ce test fait tourner le Cheater sur quatre parties avec respectivement 2, 3, 4 et 5 joueurs.
Inconvénient : les parties s'affichent à l'écran. Supprimer les prints dans un nouveau code deck.py réservé aux tests ?